### PR TITLE
Fixed race condition in MapView

### DIFF
--- a/src/components/map/MapView.svelte
+++ b/src/components/map/MapView.svelte
@@ -60,37 +60,50 @@
 		return mapProvider.getBoundingBox();
 	}
 
-	async function loadStopsForLocation(lat, lng, zoomLevel, firstCall = false) {
-		if (firstCall) {
-			const response = await fetch(`/api/oba/stops-for-location?lat=${lat}&lng=${lng}&radius=2500`);
+	async function loadStopsForLocation(lat, lng, zoomLevel, firstCall, signal) {
+		try {
+			if (firstCall) {
+				const response = await fetch(
+					`/api/oba/stops-for-location?lat=${lat}&lng=${lng}&radius=2500`,
+					{ signal }
+				);
+				if (!response.ok) {
+					throw new Error('Failed to fetch locations');
+				}
+				return await response.json();
+			}
+
+			const boundingBox = getBoundingBox();
+			const key = cacheKey(zoomLevel, boundingBox);
+
+			if (stopsCache.has(key)) {
+				console.debug('Stop cache hit:', key);
+				return stopsCache.get(key);
+			} else {
+				console.debug('Stop cache miss:', key);
+			}
+
+			const response = await fetch(
+				`/api/oba/stops-for-location?lat=${lat}&lng=${lng}&latSpan=${boundingBox.north - boundingBox.south}&lngSpan=${boundingBox.east - boundingBox.west}&radius=1500`,
+				{ signal }
+			);
+
 			if (!response.ok) {
 				throw new Error('Failed to fetch locations');
 			}
-			return await response.json();
+
+			const stopsForLocation = await response.json();
+			stopsCache.set(key, stopsForLocation);
+
+			return stopsForLocation;
+		} catch (error) {
+			if (error.name === 'AbortError') {
+				console.warn('Fetch request was aborted');
+			} else {
+				console.error('Error fetching stops:', error);
+			}
+			return null;
 		}
-
-		const boundingBox = getBoundingBox();
-		const key = cacheKey(zoomLevel, boundingBox);
-
-		if (stopsCache.has(key)) {
-			console.debug('Stop cache hit: ', key);
-			return stopsCache.get(key);
-		} else {
-			console.debug('Stop cache miss: ', key);
-		}
-
-		const response = await fetch(
-			`/api/oba/stops-for-location?lat=${lat}&lng=${lng}&latSpan=${boundingBox.north - boundingBox.south}&lngSpan=${boundingBox.east - boundingBox.west}&radius=1500`
-		);
-
-		if (!response.ok) {
-			throw new Error('Failed to fetch locations');
-		}
-
-		const stopsForLocation = await response.json();
-		stopsCache.set(key, stopsForLocation);
-
-		return stopsForLocation;
 	}
 
 	async function initMap() {
@@ -125,19 +138,36 @@
 		}
 	}
 
+	let abortController = new AbortController();
+
 	async function loadStopsAndAddMarkers(lat, lng, firstCall = false, zoomLevel = 15) {
-		const stopsData = await loadStopsForLocation(lat, lng, zoomLevel, firstCall);
-		const newStops = stopsData.data.list;
-		const routeReference = stopsData.data.references.routes || [];
+		if (abortController) {
+			abortController.abort();
+		}
 
-		const routeLookup = new Map(routeReference.map((route) => [route.id, route]));
+		abortController = new AbortController(); // Create a new controller
+		const signal = abortController.signal;
 
-		// merge the stops routeIds with the route data
-		newStops.forEach((stop) => {
-			stop.routes = stop.routeIds.map((routeId) => routeLookup.get(routeId)).filter(Boolean);
-		});
+		try {
+			const stopsData = await loadStopsForLocation(lat, lng, zoomLevel, firstCall, signal);
+			if (!stopsData) return;
 
-		allStops = [...new Map([...allStops, ...newStops].map((stop) => [stop.id, stop])).values()];
+			const newStops = stopsData.data.list;
+			const routeReference = stopsData.data.references.routes || [];
+			const routeLookup = new Map(routeReference.map((route) => [route.id, route]));
+
+			newStops.forEach((stop) => {
+				stop.routes = stop.routeIds.map((routeId) => routeLookup.get(routeId)).filter(Boolean);
+			});
+
+			allStops = [...new Map([...allStops, ...newStops].map((stop) => [stop.id, stop])).values()];
+		} catch (error) {
+			if (error.name === 'AbortError') {
+				console.warn('Request aborted intentionally');
+			} else {
+				console.error('Error loading stops:', error);
+			}
+		}
 	}
 
 	function clearAllMarkers() {

--- a/src/components/stops/StopPane.svelte
+++ b/src/components/stops/StopPane.svelte
@@ -41,7 +41,7 @@
 
 	let abortController = null;
 	async function loadData(stopID) {
-    // Cancel the previous request if it exists
+		// Cancel the previous request if it exists
 		if (abortController) {
 			abortController.abort();
 		}


### PR DESCRIPTION
Repeated zoom in and out in the mapview creates many api calls. this code drops all the calls except the newest one so that race conditions can be avoided and improved efficiency.